### PR TITLE
Fix leaked HttpURLConnection InputStreams on non-200 HTTP responses.

### DIFF
--- a/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
+++ b/src/com/akamai/netstorage/NetStorageCMSv35Signer.java
@@ -384,9 +384,13 @@ public class NetStorageCMSv35Signer {
 
             return request.getInputStream();
 
-        } catch (IOException e) {
-            if (request != null)
-                request.disconnect();
+        } catch (NetStorageException | IOException e) {
+            if (request != null) {
+                try (InputStream is = request.getInputStream()) {}
+                catch (IOException ioException) {}
+                try (InputStream is = request.getErrorStream()) {}
+                catch (IOException ioException) {}
+            }
             throw new NetStorageException("Communication Error", e);
         }
     }


### PR DESCRIPTION
I worked with @bkulatun and we discovered that when com.akamai.netstorage.NetStorageCMSv35Signer.execute() runs com.akamai.netstorage.NetStorageCMSv35Signer.validate(HttpURLConnection) and the HTTP response is non-200 then we failed to close related InputStreams. This caused file descriptor leaks and dangling sockets. This change cleans up these resources by catching NetStorageException and closing the affected streams. The HttpURLConnection is no longer disconnected because that implies killing background keep-alive connections.