### PR TITLE
Fix unit test and update response code handling for NetStorageException.

### DIFF
--- a/src/com/akamai/netstorage/NetStorageException.java
+++ b/src/com/akamai/netstorage/NetStorageException.java
@@ -37,6 +37,9 @@ public class NetStorageException extends Exception {
 
     public NetStorageException(String message, Throwable cause) {
         super(message, cause);
+        if(cause instanceof NetStorageException) {
+           responseCode = ((NetStorageException) cause).getResponseCode();
+        }
     }
 
     public int getResponseCode(){

--- a/test/com/akamai/netstorage/NetStorageCMSv35SignerTest.java
+++ b/test/com/akamai/netstorage/NetStorageCMSv35SignerTest.java
@@ -249,7 +249,6 @@ public class NetStorageCMSv35SignerTest {
         assertEquals(nse.getMessage(), "Communication Error");
         assertEquals(nse.getCause().getClass(), IOException.class);
         assertTrue(httpURLConnection.getWasConnected());
-        assertFalse(httpURLConnection.getConnected());
     }
 
     class ByteArrayInputStreamBroken extends ByteArrayInputStream {


### PR DESCRIPTION
Removing connection check for unit test because we are no longer disconnecting on an error.  Changing the NetStorageException to handle the response code of a wrapped NetStorageException.